### PR TITLE
Add User Agent Header

### DIFF
--- a/qping.py
+++ b/qping.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 #
-# Updated by Crazy Danish Hacker
+# Updated by Crazy Danish Hacker,abu
 
 import requests
 import sys
 
 timeout = 3
 verbose = True
-version = "1.0.1"
+version = "1.0.2"
 banner = """
              _             
             (_)            
@@ -20,7 +20,7 @@ banner = """
 
                       by TamilBotNet
                       version: {}
-      Updated by Crazy Danish Hacker
+      Updated by Crazy Danish Hacker,abu
 """.format(version, sys.argv[0])
 
 usage = "\n [SYNTAX]  python {} target.txt"

--- a/qping.py
+++ b/qping.py
@@ -33,7 +33,7 @@ if len(sys.argv) <= 1:
 
 # Set the output filename to be used globally
 filename = "OnlineDomains_{}".format(sys.argv[1])
-
+header={'User-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.30 (KHTML, like Gecko) Ubuntu/11.04 Chromium/12.0.742.112 Chrome/12.0.742.112 Safari/534.30'} # some site return 403 instead of 200 when request without user agent.
 
 def create_file(user_file):
     with open(user_file, "w") as output_file:
@@ -49,7 +49,7 @@ def main():
         for line in input_file:
             url = "http://{}".format(line.strip())  # Note: Strip only works at the beginning or end of a string.
             try:
-                req = requests.get(url, timeout=timeout)
+                req = requests.get(url, timeout=timeout,headers=header)
                 if req.status_code == 200:
                     extra = "- HTTP 200 OK" if verbose else ""
                     print("[+] Domain is online! ({}) {}".format(url, extra))


### PR DESCRIPTION
Some Sites return 403 instead of 200 when request without user agent.  this issue fixed with this commit

https://github.com/tamilbotnet/qping/pull/1/commits/90ac93324c41050b9eb5988446069d443bdf7c3b